### PR TITLE
Fix hourly UnboundLocalError in getDailyEnergyConsumption (energy counters stop updating)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -360,9 +360,17 @@ class RemehaHomeAPI:
         last_day_of_last_year = datetime.datetime(current_year - 1, 12, 31)
         yearly_url = f"https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/yearly?startDate=1900-01-01T00:00:00.000Z&endDate={last_day_of_last_year.strftime('%Y-%m-%dT00:00:00.000Z')}"
         
+        # Initialize so a failed GET below cannot cause an UnboundLocalError later on
+        total_heating_energy_consumed_yearly = None
+        total_heating_energy_delivered_yearly = None
+        total_heating_energy_consumed_monthly = None
+        total_heating_energy_delivered_monthly = None
+
         try:
-            yearly_data = requests.get(yearly_url, headers=headers).json()
-            
+            yearly_response = requests.get(yearly_url, headers=headers, timeout=30)
+            yearly_response.raise_for_status()
+            yearly_data = yearly_response.json()
+
             # Extract "heatingEnergyConsumed" from each row in the yearly response body
             heating_energy_consumed_values_yearly = [entry["heatingEnergyConsumed"] for entry in yearly_data["data"]]
             # Energy generated
@@ -373,7 +381,7 @@ class RemehaHomeAPI:
             # Energy generated
             total_heating_energy_delivered_yearly = sum(heating_energy_delivered_values_yearly)
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            Domoticz.Error(f"Energy consumption: yearly GET failed: {e}")
 
         # Step 2: Get all results of the previous months excluding the current month
         current_month = datetime.datetime.now().month
@@ -387,7 +395,9 @@ class RemehaHomeAPI:
         try:
             monthly_url = f"https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/monthly?startDate={datetime.datetime.now().year}-01-01T00:00:00.000Z&endDate={end_of_current_month.strftime('%Y-%m-%dT00:00:00.000Z')}"
             #print(monthly_url)
-            monthly_data = requests.get(monthly_url, headers=headers).json()
+            monthly_response = requests.get(monthly_url, headers=headers, timeout=30)
+            monthly_response.raise_for_status()
+            monthly_data = monthly_response.json()
       
             # Extract "heatingEnergyConsumed" from each row in the monthly response body
             heating_energy_consumed_values_monthly = [entry["heatingEnergyConsumed"] for entry in monthly_data["data"]]
@@ -399,13 +409,20 @@ class RemehaHomeAPI:
             # Energy delivered
             total_heating_energy_delivered_monthly = sum(heating_energy_delivered_values_monthly)
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            Domoticz.Error(f"Energy consumption: monthly GET failed: {e}")
+
+        # If either the yearly or the monthly retrieval failed, skip this cycle
+        # (the counters will simply update again at the next full hour)
+        if None in (total_heating_energy_consumed_yearly, total_heating_energy_delivered_yearly,
+                    total_heating_energy_consumed_monthly, total_heating_energy_delivered_monthly):
+            Domoticz.Error("Energy consumption: yearly/monthly data unavailable, skipping counter update this cycle")
+            return
 
          # Combine the totals consumed
         total_heating_energy_consumed = (
         total_heating_energy_consumed_yearly +
         total_heating_energy_consumed_monthly
-        ) 
+        )
         # Generated
         total_heating_energy_delivered = (
         total_heating_energy_delivered_yearly +
@@ -427,8 +444,10 @@ class RemehaHomeAPI:
         try:
             response = requests.get(
                 f'https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/daily?startDate={today_string}&endDate={end_of_today_string}',
-                headers=headers
+                headers=headers,
+                timeout=30
             )
+            response.raise_for_status()
             response_json = response.json()
             
             EnergyToday = response_json["data"][0]["heatingEnergyConsumed"]
@@ -458,7 +477,7 @@ class RemehaHomeAPI:
                 Devices[10].Update(nValue=0, sValue=str(EnergyDeliveredToday) + ";" + str(total_heating_energy_delivered))
                 Devices[12].Update(nValue=0, sValue=str(value_seasonalEfficiency), Options={"Custom": "1;SCOP"})
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            Domoticz.Error(f"Energy consumption: daily GET failed: {e}")
 
 
     def check_token_validity(self,acces_token):


### PR DESCRIPTION
## Problem

The Domoticz log fills with this error every hour at xx:06:

```
Error: Remeha: Error making POST request: cannot access local variable 'total_heating_energy_consumed_yearly' where it is not associated with a value
```

and the energy counter devices stop updating.

## Root cause

In `getDailyEnergyConsumption()` the yearly/monthly totals are assigned **inside** `try:` blocks, but used after them. When the yearly GET fails (network hiccup, API error, token issue), the variable is never assigned and the code crashes with an `UnboundLocalError` — which then gets caught by `onheartbeat()`'s handler and logged as a misleading "Error making POST request". The *real* API error is only `print()`-ed, which never reaches the Domoticz log, so there is no way to see what actually went wrong.

## Changes

- Initialize the yearly/monthly totals to `None` before the `try:` blocks; if either retrieval failed, log it and **skip the counter update for this cycle** (it simply retries at the next full hour) instead of crashing.
- Replace `print()` with `Domoticz.Error()` in the three energy handlers, with distinct labels (`yearly GET failed` / `monthly GET failed` / `daily GET failed`), so the actual API error becomes visible in the Domoticz log.
- Add `response.raise_for_status()` after each GET so an HTTP 4xx/5xx is reported as such instead of surfacing as a confusing `KeyError: 'data'`.
- Add `timeout=30` to the three energy GETs — they had no timeout, so a hanging request would block the plugin heartbeat indefinitely.

No functional change when the API calls succeed.
