### PR TITLE
Avoid hardware not responding error

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -31,6 +31,8 @@ class RemehaHomeAPI:
         self._session = requests.Session()
         self.email = ""
         self.password = ""
+        self.LastWebUpdate = None
+
 
     def _request_with_retry(self, method, url, max_retries=3, timeout=5, **kwargs):
         """Helper method to make requests with retry logic and 5 second timeout."""
@@ -633,8 +635,10 @@ class RemehaHomeAPI:
             return "invalid"
 
     def onheartbeat(self):
-        # Heartbeat function called periodically
-        Domoticz.Heartbeat(self.poll_interval)
+        # Check update interval avoiding setting heartbeat > 30
+        if self.LastWebUpdate is not None and (datetime.datetime.now() - self.LastWebUpdate).total_seconds() < self.poll_interval:
+            return
+        self.LastWebUpdate = datetime.datetime.now()
         Domoticz.Log("Remeha Home plugin heartbeat")
         current_time_minutes = time.localtime().tm_min
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,5 @@
 """
-<plugin key="RemehaHome" name="Remeha Home Plugin" author="Nick Baring/GizMoCuz" version="1.3.0">
+<plugin key="RemehaHome" name="Remeha Home Plugin" author="Nick Baring/GizMoCuz" version="1.3.1">
     <params>
         <param field="Mode1" label="Email" width="200px" required="true"/>
         <param field="Mode2" label="Password" width="200px" password="true" required="true"/>
@@ -117,7 +117,8 @@ class RemehaHomeAPI:
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            Domoticz.Error(f"Error authorize: {str(e)}")
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Authorize error: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -161,7 +162,8 @@ class RemehaHomeAPI:
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            Domoticz.Error(f"Error during GET request for SelfAsserted: {str(e)}")
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for SelfAsserted: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -187,7 +189,8 @@ class RemehaHomeAPI:
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {str(e)}")
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -327,6 +330,10 @@ class RemehaHomeAPI:
                 Devices[9].Update(nValue=1, sValue="On")
             Devices[11].Update(nValue=0, sValue=str(value_status))
 
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for dashboard: {type(e).__name__}: {reason}")
+            return None
 
         except Exception as e:
             Domoticz.Error(f"Error making GET request: {e}")

--- a/plugin.py
+++ b/plugin.py
@@ -157,6 +157,7 @@ class RemehaHomeAPI:
                     "signInName": self.email,
                     "password": self.password,
                 },
+                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -221,6 +222,7 @@ class RemehaHomeAPI:
             "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/token?p=B2C_1A_RPSignUpSignInNewRoomV3.1",
             data=grant_params,
             allow_redirects=True,
+            timeout=10,
         ) as response:
             if response.status_code != 200:
                 response_json = response.json()
@@ -342,13 +344,15 @@ class RemehaHomeAPI:
                 response = self._session.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/manual',
                     headers=headers,
-                    json=json_data
+                    json=json_data,
+                    timeout=10,
                     )
             else: # zonemode is not manual then temporary override
                 response = self._session.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/temporary-override',
                     headers=headers,
-                    json=json_data
+                    json=json_data,
+                    timeout=10,
                     )
             response.raise_for_status()
             Domoticz.Log(f"Temperature set successfully to {room_temperature_setpoint}")
@@ -526,14 +530,16 @@ class RemehaHomeAPI:
                 response = self._session.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/temporary-override',
                     headers=headers,
-                    json=json_data
+                    json=json_data,
+                    timeout=10,
                     )
                 response.raise_for_status()
                 Domoticz.Log("Zonemode succesfully set to TemporaryOverride")
             elif level == 30: # FrostProtection mode
                 response = self._session.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/anti-frost',
-                    headers=headers
+                    headers=headers,
+                    timeout=10,
                     )
                 response.raise_for_status()
                 Domoticz.Log("Zonemode succesfully set to FrostProtection")

--- a/plugin.py
+++ b/plugin.py
@@ -18,149 +18,38 @@ import Domoticz
 import base64
 import hashlib
 import json
-import urllib.request
-import urllib.error
-import urllib.parse
-import http.cookiejar
+import urllib
 import secrets
+import requests
 import datetime
 import calendar
 import time
 
 class RemehaHomeAPI:
     def __init__(self):
-        # Initialize a cookie jar and urllib opener to replace `requests`
-        self._cookie_jar = http.cookiejar.CookieJar()
-        self._opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self._cookie_jar))
+        # Initialize a session for making HTTP requests
+        self._session = requests.Session()
         self.email = ""
         self.password = ""
         self.LastWebUpdate = None
 
 
     def _request_with_retry(self, method, url, max_retries=3, timeout=5, **kwargs):
-        """Make HTTP requests using urllib with retries.
-
-        Returns a Response-like object with attributes: status_code, headers, text, json(),
-        and raise_for_status(). Supported kwargs: params, headers, data, json, allow_redirects
-        """
-        params = kwargs.get('params')
-        headers = kwargs.get('headers') or {}
-        data = kwargs.get('data')
-        json_body = kwargs.get('json')
-        allow_redirects = kwargs.get('allow_redirects', True)
-
-        last_exc = None
+        """Helper method to make requests with retry logic and 5 second timeout."""
         for attempt in range(max_retries):
             try:
-                # Build URL with params
-                parsed = urllib.parse.urlparse(url)
-                base_path = parsed.scheme + '://' + parsed.netloc + parsed.path
-                query_parts = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True) if parsed.query else []
-                if params:
-                    if isinstance(params, dict):
-                        for k, v in params.items():
-                            if isinstance(v, (list, tuple)):
-                                for item in v:
-                                    query_parts.append((k, str(item)))
-                            else:
-                                query_parts.append((k, str(v)))
-                    else:
-                        extra_q = urllib.parse.parse_qsl(str(params), keep_blank_values=True)
-                        query_parts.extend(extra_q)
-                if query_parts:
-                    url_with_q = base_path + '?' + urllib.parse.urlencode(query_parts, doseq=True)
+                if method.lower() == 'get':
+                    response = self._session.get(url, timeout=timeout, **kwargs)
+                elif method.lower() == 'post':
+                    response = self._session.post(url, timeout=timeout, **kwargs)
                 else:
-                    url_with_q = base_path
-
-                body = None
-                if json_body is not None:
-                    body = json.dumps(json_body).encode('utf-8')
-                    headers.setdefault('Content-Type', 'application/json; charset=utf-8')
-                elif data is not None:
-                    if isinstance(data, dict):
-                        body = urllib.parse.urlencode(data).encode('utf-8')
-                        headers.setdefault('Content-Type', 'application/x-www-form-urlencoded')
-                    else:
-                        body = str(data).encode('utf-8')
-
-                req = urllib.request.Request(url_with_q, data=body, method=method.upper())
-                for k, v in headers.items():
-                    req.add_header(k, v)
-
-                # Execute request. Honor allow_redirects by using a temporary no-redirect handler.
-                if not allow_redirects:
-                    class _NoRedirect(urllib.request.HTTPRedirectHandler):
-                        def redirect_request(self, req, fp, code, msg, headers, newurl):
-                            return None
-                        def http_error_301(self, req, fp, code, msg, headers):
-                            return fp
-                        def http_error_302(self, req, fp, code, msg, headers):
-                            return fp
-                        def http_error_303(self, req, fp, code, msg, headers):
-                            return fp
-                        def http_error_307(self, req, fp, code, msg, headers):
-                            return fp
-                        def http_error_308(self, req, fp, code, msg, headers):
-                            return fp
-
-                    tmp_opener = urllib.request.build_opener(_NoRedirect(), urllib.request.HTTPCookieProcessor(self._cookie_jar))
-                    resp = tmp_opener.open(req, timeout=timeout)
-                else:
-                    resp = self._opener.open(req, timeout=timeout)
-
-                resp_body = resp.read().decode('utf-8', errors='replace')
-                resp_headers = {k: v for k, v in resp.getheaders()}
-                status = resp.getcode()
-                return RemehaHomeAPI._Response(status_code=status, headers=resp_headers, body=resp_body)
-            except urllib.error.HTTPError as e:
-                last_exc = e
-                try:
-                    err_body = e.read().decode('utf-8', errors='replace')
-                    Domoticz.Log(f"HTTPError body: {err_body}")
-                except Exception:
-                    pass
-                # if redirect and caller wanted no redirects, return response-like
-                try:
-                    code = getattr(e, 'code', None)
-                    resp_headers = {}
-                    try:
-                        resp_headers = {k: v for k, v in e.headers.items()} if getattr(e, 'headers', None) else {}
-                    except Exception:
-                        resp_headers = {}
-                    if code and (300 <= int(code) < 400) and not allow_redirects:
-                        return RemehaHomeAPI._Response(status_code=code, headers=resp_headers, body=err_body)
-                except Exception:
-                    pass
-                if attempt == max_retries - 1:
-                    raise
-                Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: HTTPError {getattr(e, 'code', e)}")
-                time.sleep(1)
-            except urllib.error.URLError as e:
-                last_exc = e
-                if attempt == max_retries - 1:
-                    raise
-                Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: URLError {e.reason}")
-                time.sleep(1)
-            except Exception as e:
-                last_exc = e
+                    raise ValueError(f"Unsupported method: {method}")
+                return response
+            except requests.exceptions.RequestException as e:
                 if attempt == max_retries - 1:
                     raise
                 Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: {e}")
-                time.sleep(1)
-        if last_exc:
-            raise last_exc
         return None
-
-    class _Response:
-        def __init__(self, status_code=0, headers=None, body=''):
-            self.status_code = status_code
-            self.headers = headers or {}
-            self.text = body
-        def json(self):
-            return json.loads(self.text) if self.text else {}
-        def raise_for_status(self):
-            if self.status_code and int(self.status_code) >= 400:
-                raise Exception(f"HTTP {self.status_code}")
 
     def onStart(self):
         # Called when the plugin is started
@@ -230,7 +119,6 @@ class RemehaHomeAPI:
             response = self._request_with_retry(
                 "get",
                 "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/authorize",
-                allow_redirects=False,
                 params={
                     "response_type": "code",
                     "client_id": "6ce007c6-0628-419e-88f4-bee2e6418eec",
@@ -248,18 +136,19 @@ class RemehaHomeAPI:
                 },
             )
             response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Authorize error: {type(e).__name__}: {reason}")
+            return None
         except Exception as e:
-            Domoticz.Error(f"Authorize error: {type(e).__name__}: {e}")
+            Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
             return None
 
         if response.status_code != 200:
             Domoticz.Error(f"Error received from server (authorize): {response.status_code}")
             return None
 
-        # Case-insensitive header lookup, with gateway fallback
-        resp_headers = getattr(response, 'headers', {}) or {}
-        headers_lower = {k.lower(): v for k, v in resp_headers.items()}
-        request_id = headers_lower.get('x-request-id') or headers_lower.get('x-ms-gateway-requestid')
+        request_id = response.headers["x-request-id"]
         state_properties_json = f'{{"TID":"{request_id}"}}'.encode("ascii")
         state_properties = (
             base64.urlsafe_b64encode(state_properties_json)
@@ -267,14 +156,14 @@ class RemehaHomeAPI:
             .rstrip("=")
         )
 
-        csrf_token = None
-        try:
-            for cookie in self._cookie_jar:
-                if getattr(cookie, 'name', '') == 'x-ms-cpim-csrf':
-                    csrf_token = cookie.value
-                    break
-        except Exception:
-            csrf_token = None
+        csrf_token = next(
+            cookie.value
+            for cookie in self._session.cookies
+            if (
+                cookie.name == "x-ms-cpim-csrf"
+                and cookie.domain == ".remehalogin.bdrthermea.net"
+            )
+        )
 
         try:
             response = self._request_with_retry(
@@ -292,8 +181,9 @@ class RemehaHomeAPI:
                 },
             )
             response.raise_for_status()
-        except Exception as e:
-            Domoticz.Error(f"Error during GET request for SelfAsserted: {type(e).__name__}: {e}")
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for SelfAsserted: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -318,8 +208,9 @@ class RemehaHomeAPI:
                 allow_redirects=False,
             )
             response.raise_for_status()
-        except Exception as e:
-            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {type(e).__name__}: {e}")
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -329,21 +220,15 @@ class RemehaHomeAPI:
             Domoticz.Error(f"Error received from server (signin_2): {response.status_code}")
             return None
 
-        resp_headers = getattr(response, 'headers', {}) or {}
-        headers_lower = {k.lower(): v for k, v in resp_headers.items()}
-        location_value = headers_lower.get('location', '')
-        if not location_value:
+        parsed_callback_url = urllib.parse.urlparse(response.headers["location"])
+        if parsed_callback_url is None:
             Domoticz.Error("Invalid response, check authorization")
-            Domoticz.Log(f"CombinedSigninAndSignup headers: {resp_headers}")
             return None
-        parsed_callback_url = urllib.parse.urlparse(location_value)
         query_string_dict = urllib.parse.parse_qs(parsed_callback_url.query)
         if "code" not in query_string_dict:
             Domoticz.Error("Invalid response, check authorization")
-            Domoticz.Log(f"Parsed callback URL: {parsed_callback_url}")
             return None
-        # parse_qs returns lists for each key; take the first value
-        authorization_code = query_string_dict["code"][0]
+        authorization_code = query_string_dict["code"]
 
         grant_params = {
             "grant_type": "authorization_code",
@@ -371,8 +256,9 @@ class RemehaHomeAPI:
                 )
             response.raise_for_status()
             response_json = response.json()
-        except Exception as e:
-            Domoticz.Error(f"new access token error: {type(e).__name__}: {e}")
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"new access token error: {type(e).__name__}: {reason}")
             return None
         except Exception as e:
             Domoticz.Error(f"new access token error: {e}")
@@ -380,12 +266,8 @@ class RemehaHomeAPI:
         return response_json
 
     def cleanup(self):
-        # Cleanup session resources (cookiejar used; nothing to close)
-        try:
-            # clear cookies
-            self._cookie_jar.clear()
-        except Exception:
-            pass
+        # Cleanup session resources
+        self._session.close()
 
     def update_devices(self, access_token):
         # Update Domoticz devices with data from Remeha Home
@@ -490,6 +372,11 @@ class RemehaHomeAPI:
                     Devices[13].Update(nValue=0, sValue="Off")
             else:
                 Devices[13].Update(nValue=0, sValue="Off")
+
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"Error during GET request for dashboard: {type(e).__name__}: {reason}")
+            return None
 
         except Exception as e:
             Domoticz.Error(f"Error making GET request: {e}")
@@ -724,23 +611,21 @@ class RemehaHomeAPI:
         try:
             if str(value_firePlaceModeActive) == "True": # Fireplace mode currently on
                 json_data = {"fireplaceModeActive": False}
-                response = self._request_with_retry(
-                    "post",
+                response = requests.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/fireplacemode',
                     headers=headers,
-                    json=json_data,
-                )
+                    json=json_data
+                    )
                 response.raise_for_status()
                 Devices[13].Update(nValue=0, sValue="Off")
                 Domoticz.Log("Fireplace Mode succesfully set to false")
             elif str(value_firePlaceModeActive) == "False": # Fireplace mode currently off
                 json_data = {"fireplaceModeActive": True}
-                response = self._request_with_retry(
-                    "post",
+                response = requests.post(
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/fireplacemode',
                     headers=headers,
-                    json=json_data,
-                )
+                    json=json_data
+                    )
                 response.raise_for_status()
                 Devices[13].Update(nValue=1, sValue="On")
                 Domoticz.Log("Fireplace Mode succesfully set to true")

--- a/plugin.py
+++ b/plugin.py
@@ -61,6 +61,8 @@ class RemehaHomeAPI:
         if len(Devices) != 13:
             # Example: Create devices for temperature, pressure, and setpoint
             self.createDevices()
+
+        # Set the poll interval to 5 seconds and test for the set real update time in onheartbeat() to allow for longer than 30 seconds
         Domoticz.Heartbeat(5)
         Domoticz.Log(f"Poll Interval: {self.poll_interval}")
 
@@ -379,7 +381,7 @@ class RemehaHomeAPI:
             return None
 
         except Exception as e:
-            Domoticz.Error(f"Error making GET request: {e}")
+            Domoticz.Error(f"1.Error making GET request: {e}")
 
     def set_temperature(self, access_token, room_temperature_setpoint):
         # Set temperature in the external system using a POST request
@@ -407,7 +409,7 @@ class RemehaHomeAPI:
             response.raise_for_status()
             Domoticz.Log(f"Temperature set successfully to {room_temperature_setpoint}")
         except Exception as e:
-            Domoticz.Error(f"Error making POST request: {e}")
+            Domoticz.Error(f"2.Error making POST request: {e}")
 
     def getDailyEnergyConsumption(self, access_token):
         headers = {
@@ -436,7 +438,8 @@ class RemehaHomeAPI:
             # Energy generated
             total_heating_energy_delivered_yearly = sum(heating_energy_delivered_values_yearly)
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            print(f"3.Error making GET request: {e}")
+            return
 
         # Step 2: Get all results of the previous months excluding the current month
         current_month = datetime.datetime.now().month
@@ -463,7 +466,8 @@ class RemehaHomeAPI:
             # Energy delivered
             total_heating_energy_delivered_monthly = sum(heating_energy_delivered_values_monthly)
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            print(f"4.Error making GET request: {e}")
+            return
 
          # Combine the totals consumed
         total_heating_energy_consumed = (
@@ -523,7 +527,7 @@ class RemehaHomeAPI:
                 Devices[10].Update(nValue=0, sValue=str(EnergyDeliveredToday) + ";" + str(total_heating_energy_delivered))
                 Devices[12].Update(nValue=0, sValue=str(value_seasonalEfficiency), Options={"Custom": "1;SCOP"})
         except Exception as e:
-            print(f"Error making GET request: {e}")
+            print(f"5.Error making GET request: {e}")
 
 
     def check_token_validity(self,acces_token):
@@ -635,12 +639,13 @@ class RemehaHomeAPI:
             return "invalid"
 
     def onheartbeat(self):
-        # Check update interval avoiding setting heartbeat > 30
+        # Check update interval ourselves to avoid error for heartbeat longer than 30 seconds cause hardware errors in domoticz
         if self.LastWebUpdate is not None and (datetime.datetime.now() - self.LastWebUpdate).total_seconds() < self.poll_interval:
             return
         self.LastWebUpdate = datetime.datetime.now()
         Domoticz.Log("Remeha Home plugin heartbeat")
         current_time_minutes = time.localtime().tm_min
+        current_time_seconds = time.localtime().tm_sec
 
         # Check if the access token exists in the instance variable self and if it's valid
         access_token = getattr(self, 'access_token', None)
@@ -649,10 +654,10 @@ class RemehaHomeAPI:
                 self.update_devices(access_token)
                 # Check if the current time in minutes is 5, then get the daily energy consumption
                 # The API seems to be only updated once an hour so no use to run it more often.
-                if current_time_minutes == 5:
-                    self.getDailyEnergyConsumption(access_token)
             except Exception as e:
-                Domoticz.Error(f"Error making POST request: {e}")
+                Domoticz.Error(f"6.Error making POST request: {e}")
+            if current_time_minutes == 5 and current_time_seconds < 30:
+                self.getDailyEnergyConsumption(access_token)
         else:
             # Access token is expired or doesn't exist in the session, get a new one
             result = self.resolve_external_data()
@@ -664,10 +669,10 @@ class RemehaHomeAPI:
                     self.update_devices(access_token)
                     # Check if the current time in minutes is 5, then get the daily energy consumption
                     # The API seems to be only updated once an hour so no use to run it more often.
-                    if current_time_minutes == 5:
+                    if current_time_minutes == 5 and current_time_seconds < 30:
                         self.getDailyEnergyConsumption(access_token)
                 except Exception as e:
-                    Domoticz.Error(f"Error making POST request: {e}")
+                    Domoticz.Error(f"7.Error making POST request: {e}")
         self.cleanup()
 
     def oncommand(self, unit, command, level, hue):
@@ -684,7 +689,7 @@ class RemehaHomeAPI:
                 elif unit == 13: # fireplace mode
                     self.fireplacemode(access_token, level)
             except Exception as e:
-                Domoticz.Error(f"Error making POST request: {e}")
+                Domoticz.Error(f"8.Error making POST request: {e}")
         else:
              # Access token is expired or doesn't exist in the session, get a new one
             result = self.resolve_external_data()
@@ -698,7 +703,7 @@ class RemehaHomeAPI:
                             room_temperature_setpoint = float(level)
                             self.set_temperature(access_token, room_temperature_setpoint)
                 except Exception as e:
-                    Domoticz.Error(f"Error making POST request: {e}")
+                    Domoticz.Error(f"9.Error making POST request: {e}")
         self.cleanup()
 
 # Create an instance of the RemehaHomeAPI class

--- a/plugin.py
+++ b/plugin.py
@@ -18,38 +18,149 @@ import Domoticz
 import base64
 import hashlib
 import json
-import urllib
+import urllib.request
+import urllib.error
+import urllib.parse
+import http.cookiejar
 import secrets
-import requests
 import datetime
 import calendar
 import time
 
 class RemehaHomeAPI:
     def __init__(self):
-        # Initialize a session for making HTTP requests
-        self._session = requests.Session()
+        # Initialize a cookie jar and urllib opener to replace `requests`
+        self._cookie_jar = http.cookiejar.CookieJar()
+        self._opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self._cookie_jar))
         self.email = ""
         self.password = ""
         self.LastWebUpdate = None
 
 
     def _request_with_retry(self, method, url, max_retries=3, timeout=5, **kwargs):
-        """Helper method to make requests with retry logic and 5 second timeout."""
+        """Make HTTP requests using urllib with retries.
+
+        Returns a Response-like object with attributes: status_code, headers, text, json(),
+        and raise_for_status(). Supported kwargs: params, headers, data, json, allow_redirects
+        """
+        params = kwargs.get('params')
+        headers = kwargs.get('headers') or {}
+        data = kwargs.get('data')
+        json_body = kwargs.get('json')
+        allow_redirects = kwargs.get('allow_redirects', True)
+
+        last_exc = None
         for attempt in range(max_retries):
             try:
-                if method.lower() == 'get':
-                    response = self._session.get(url, timeout=timeout, **kwargs)
-                elif method.lower() == 'post':
-                    response = self._session.post(url, timeout=timeout, **kwargs)
+                # Build URL with params
+                parsed = urllib.parse.urlparse(url)
+                base_path = parsed.scheme + '://' + parsed.netloc + parsed.path
+                query_parts = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True) if parsed.query else []
+                if params:
+                    if isinstance(params, dict):
+                        for k, v in params.items():
+                            if isinstance(v, (list, tuple)):
+                                for item in v:
+                                    query_parts.append((k, str(item)))
+                            else:
+                                query_parts.append((k, str(v)))
+                    else:
+                        extra_q = urllib.parse.parse_qsl(str(params), keep_blank_values=True)
+                        query_parts.extend(extra_q)
+                if query_parts:
+                    url_with_q = base_path + '?' + urllib.parse.urlencode(query_parts, doseq=True)
                 else:
-                    raise ValueError(f"Unsupported method: {method}")
-                return response
-            except requests.exceptions.RequestException as e:
+                    url_with_q = base_path
+
+                body = None
+                if json_body is not None:
+                    body = json.dumps(json_body).encode('utf-8')
+                    headers.setdefault('Content-Type', 'application/json; charset=utf-8')
+                elif data is not None:
+                    if isinstance(data, dict):
+                        body = urllib.parse.urlencode(data).encode('utf-8')
+                        headers.setdefault('Content-Type', 'application/x-www-form-urlencoded')
+                    else:
+                        body = str(data).encode('utf-8')
+
+                req = urllib.request.Request(url_with_q, data=body, method=method.upper())
+                for k, v in headers.items():
+                    req.add_header(k, v)
+
+                # Execute request. Honor allow_redirects by using a temporary no-redirect handler.
+                if not allow_redirects:
+                    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+                        def redirect_request(self, req, fp, code, msg, headers, newurl):
+                            return None
+                        def http_error_301(self, req, fp, code, msg, headers):
+                            return fp
+                        def http_error_302(self, req, fp, code, msg, headers):
+                            return fp
+                        def http_error_303(self, req, fp, code, msg, headers):
+                            return fp
+                        def http_error_307(self, req, fp, code, msg, headers):
+                            return fp
+                        def http_error_308(self, req, fp, code, msg, headers):
+                            return fp
+
+                    tmp_opener = urllib.request.build_opener(_NoRedirect(), urllib.request.HTTPCookieProcessor(self._cookie_jar))
+                    resp = tmp_opener.open(req, timeout=timeout)
+                else:
+                    resp = self._opener.open(req, timeout=timeout)
+
+                resp_body = resp.read().decode('utf-8', errors='replace')
+                resp_headers = {k: v for k, v in resp.getheaders()}
+                status = resp.getcode()
+                return RemehaHomeAPI._Response(status_code=status, headers=resp_headers, body=resp_body)
+            except urllib.error.HTTPError as e:
+                last_exc = e
+                try:
+                    err_body = e.read().decode('utf-8', errors='replace')
+                    Domoticz.Log(f"HTTPError body: {err_body}")
+                except Exception:
+                    pass
+                # if redirect and caller wanted no redirects, return response-like
+                try:
+                    code = getattr(e, 'code', None)
+                    resp_headers = {}
+                    try:
+                        resp_headers = {k: v for k, v in e.headers.items()} if getattr(e, 'headers', None) else {}
+                    except Exception:
+                        resp_headers = {}
+                    if code and (300 <= int(code) < 400) and not allow_redirects:
+                        return RemehaHomeAPI._Response(status_code=code, headers=resp_headers, body=err_body)
+                except Exception:
+                    pass
+                if attempt == max_retries - 1:
+                    raise
+                Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: HTTPError {getattr(e, 'code', e)}")
+                time.sleep(1)
+            except urllib.error.URLError as e:
+                last_exc = e
+                if attempt == max_retries - 1:
+                    raise
+                Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: URLError {e.reason}")
+                time.sleep(1)
+            except Exception as e:
+                last_exc = e
                 if attempt == max_retries - 1:
                     raise
                 Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: {e}")
+                time.sleep(1)
+        if last_exc:
+            raise last_exc
         return None
+
+    class _Response:
+        def __init__(self, status_code=0, headers=None, body=''):
+            self.status_code = status_code
+            self.headers = headers or {}
+            self.text = body
+        def json(self):
+            return json.loads(self.text) if self.text else {}
+        def raise_for_status(self):
+            if self.status_code and int(self.status_code) >= 400:
+                raise Exception(f"HTTP {self.status_code}")
 
     def onStart(self):
         # Called when the plugin is started
@@ -119,6 +230,7 @@ class RemehaHomeAPI:
             response = self._request_with_retry(
                 "get",
                 "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/authorize",
+                allow_redirects=False,
                 params={
                     "response_type": "code",
                     "client_id": "6ce007c6-0628-419e-88f4-bee2e6418eec",
@@ -136,19 +248,18 @@ class RemehaHomeAPI:
                 },
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            reason = getattr(e, 'reason', e)
-            Domoticz.Error(f"Authorize error: {type(e).__name__}: {reason}")
-            return None
         except Exception as e:
-            Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
+            Domoticz.Error(f"Authorize error: {type(e).__name__}: {e}")
             return None
 
         if response.status_code != 200:
             Domoticz.Error(f"Error received from server (authorize): {response.status_code}")
             return None
 
-        request_id = response.headers["x-request-id"]
+        # Case-insensitive header lookup, with gateway fallback
+        resp_headers = getattr(response, 'headers', {}) or {}
+        headers_lower = {k.lower(): v for k, v in resp_headers.items()}
+        request_id = headers_lower.get('x-request-id') or headers_lower.get('x-ms-gateway-requestid')
         state_properties_json = f'{{"TID":"{request_id}"}}'.encode("ascii")
         state_properties = (
             base64.urlsafe_b64encode(state_properties_json)
@@ -156,14 +267,14 @@ class RemehaHomeAPI:
             .rstrip("=")
         )
 
-        csrf_token = next(
-            cookie.value
-            for cookie in self._session.cookies
-            if (
-                cookie.name == "x-ms-cpim-csrf"
-                and cookie.domain == ".remehalogin.bdrthermea.net"
-            )
-        )
+        csrf_token = None
+        try:
+            for cookie in self._cookie_jar:
+                if getattr(cookie, 'name', '') == 'x-ms-cpim-csrf':
+                    csrf_token = cookie.value
+                    break
+        except Exception:
+            csrf_token = None
 
         try:
             response = self._request_with_retry(
@@ -181,9 +292,8 @@ class RemehaHomeAPI:
                 },
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            reason = getattr(e, 'reason', e)
-            Domoticz.Error(f"Error during GET request for SelfAsserted: {type(e).__name__}: {reason}")
+        except Exception as e:
+            Domoticz.Error(f"Error during GET request for SelfAsserted: {type(e).__name__}: {e}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -208,9 +318,8 @@ class RemehaHomeAPI:
                 allow_redirects=False,
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            reason = getattr(e, 'reason', e)
-            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {type(e).__name__}: {reason}")
+        except Exception as e:
+            Domoticz.Error(f"Error during GET request for CombinedSigninAndSignup: {type(e).__name__}: {e}")
             return None
         except Exception as e:
             Domoticz.Error(f"Unexpected error during GET request: {str(e)}")
@@ -220,15 +329,21 @@ class RemehaHomeAPI:
             Domoticz.Error(f"Error received from server (signin_2): {response.status_code}")
             return None
 
-        parsed_callback_url = urllib.parse.urlparse(response.headers["location"])
-        if parsed_callback_url is None:
+        resp_headers = getattr(response, 'headers', {}) or {}
+        headers_lower = {k.lower(): v for k, v in resp_headers.items()}
+        location_value = headers_lower.get('location', '')
+        if not location_value:
             Domoticz.Error("Invalid response, check authorization")
+            Domoticz.Log(f"CombinedSigninAndSignup headers: {resp_headers}")
             return None
+        parsed_callback_url = urllib.parse.urlparse(location_value)
         query_string_dict = urllib.parse.parse_qs(parsed_callback_url.query)
         if "code" not in query_string_dict:
             Domoticz.Error("Invalid response, check authorization")
+            Domoticz.Log(f"Parsed callback URL: {parsed_callback_url}")
             return None
-        authorization_code = query_string_dict["code"]
+        # parse_qs returns lists for each key; take the first value
+        authorization_code = query_string_dict["code"][0]
 
         grant_params = {
             "grant_type": "authorization_code",
@@ -256,9 +371,8 @@ class RemehaHomeAPI:
                 )
             response.raise_for_status()
             response_json = response.json()
-        except requests.exceptions.RequestException as e:
-            reason = getattr(e, 'reason', e)
-            Domoticz.Error(f"new access token error: {type(e).__name__}: {reason}")
+        except Exception as e:
+            Domoticz.Error(f"new access token error: {type(e).__name__}: {e}")
             return None
         except Exception as e:
             Domoticz.Error(f"new access token error: {e}")
@@ -266,8 +380,12 @@ class RemehaHomeAPI:
         return response_json
 
     def cleanup(self):
-        # Cleanup session resources
-        self._session.close()
+        # Cleanup session resources (cookiejar used; nothing to close)
+        try:
+            # clear cookies
+            self._cookie_jar.clear()
+        except Exception:
+            pass
 
     def update_devices(self, access_token):
         # Update Domoticz devices with data from Remeha Home
@@ -373,9 +491,8 @@ class RemehaHomeAPI:
             else:
                 Devices[13].Update(nValue=0, sValue="Off")
 
-        except requests.exceptions.RequestException as e:
-            reason = getattr(e, 'reason', e)
-            Domoticz.Error(f"Error during GET request for dashboard: {type(e).__name__}: {reason}")
+        except Exception as e:
+            Domoticz.Error(f"Error during GET request for dashboard: {type(e).__name__}: {e}")
             return None
 
         except Exception as e:
@@ -611,21 +728,23 @@ class RemehaHomeAPI:
         try:
             if str(value_firePlaceModeActive) == "True": # Fireplace mode currently on
                 json_data = {"fireplaceModeActive": False}
-                response = requests.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/fireplacemode',
                     headers=headers,
-                    json=json_data
-                    )
+                    json=json_data,
+                )
                 response.raise_for_status()
                 Devices[13].Update(nValue=0, sValue="Off")
                 Domoticz.Log("Fireplace Mode succesfully set to false")
             elif str(value_firePlaceModeActive) == "False": # Fireplace mode currently off
                 json_data = {"fireplaceModeActive": True}
-                response = requests.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/fireplacemode',
                     headers=headers,
-                    json=json_data
-                    )
+                    json=json_data,
+                )
                 response.raise_for_status()
                 Devices[13].Update(nValue=1, sValue="On")
                 Domoticz.Log("Fireplace Mode succesfully set to true")

--- a/plugin.py
+++ b/plugin.py
@@ -113,6 +113,7 @@ class RemehaHomeAPI:
                     "prompt": "login",
                     "signUp": "False",
                 },
+                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -181,6 +182,7 @@ class RemehaHomeAPI:
                     "p": "B2C_1A_RPSignUpSignInNewRoomv3.1",
                 },
                 allow_redirects=False,
+                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -251,7 +253,7 @@ class RemehaHomeAPI:
         #Domoticz.Log("Getting device states...")
         try:
             response = self._session.get(
-                "https://api.bdrthermea.net/Mobile/api/homes/dashboard", headers=headers
+                "https://api.bdrthermea.net/Mobile/api/homes/dashboard", headers=headers, timeout=10
             )
 
             response.raise_for_status()

--- a/plugin.py
+++ b/plugin.py
@@ -431,7 +431,11 @@ class RemehaHomeAPI:
         total_heating_energy_delivered_monthly = None
 
         try:
-            yearly_response = requests.get(yearly_url, headers=headers, timeout=30)
+            yearly_response = self._request_with_retry(
+                "get",
+                yearly_url,
+                headers=headers
+            )
             yearly_response.raise_for_status()
             yearly_data = yearly_response.json()
 
@@ -459,7 +463,12 @@ class RemehaHomeAPI:
         try:
             monthly_url = f"https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/monthly?startDate={datetime.datetime.now().year}-01-01T00:00:00.000Z&endDate={end_of_current_month.strftime('%Y-%m-%dT00:00:00.000Z')}"
             #print(monthly_url)
-            monthly_response = requests.get(monthly_url, headers=headers, timeout=30)
+            monthly_response = self._request_with_retry(
+                "get",
+                monthly_url,
+                headers=headers
+            )
+
             monthly_response.raise_for_status()
             monthly_data = monthly_response.json()
 
@@ -509,8 +518,7 @@ class RemehaHomeAPI:
             response = self._request_with_retry(
                 "get",
                 f'https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/daily?startDate={today_string}&endDate={end_of_today_string}',
-                headers=headers,
-                timeout=30
+                headers=headers
             )
             response.raise_for_status()
             response_json = response.json()

--- a/plugin.py
+++ b/plugin.py
@@ -32,6 +32,23 @@ class RemehaHomeAPI:
         self.email = ""
         self.password = ""
 
+    def _request_with_retry(self, method, url, max_retries=3, timeout=5, **kwargs):
+        """Helper method to make requests with retry logic and 5 second timeout."""
+        for attempt in range(max_retries):
+            try:
+                if method.lower() == 'get':
+                    response = self._session.get(url, timeout=timeout, **kwargs)
+                elif method.lower() == 'post':
+                    response = self._session.post(url, timeout=timeout, **kwargs)
+                else:
+                    raise ValueError(f"Unsupported method: {method}")
+                return response
+            except requests.exceptions.RequestException as e:
+                if attempt == max_retries - 1:
+                    raise
+                Domoticz.Log(f"Retry attempt {attempt + 1}/{max_retries} for {method.upper()} {url}: {e}")
+        return None
+
     def onStart(self):
         # Called when the plugin is started
         Domoticz.Log("Remeha Home Plugin started.")
@@ -96,7 +113,8 @@ class RemehaHomeAPI:
         )
 
         try:
-            response = self._session.get(
+            response = self._request_with_retry(
+                "get",
                 "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/authorize",
                 params={
                     "response_type": "code",
@@ -113,7 +131,6 @@ class RemehaHomeAPI:
                     "prompt": "login",
                     "signUp": "False",
                 },
-                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -146,7 +163,8 @@ class RemehaHomeAPI:
         )
 
         try:
-            response = self._session.post(
+            response = self._request_with_retry(
+                "post",
                 "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/B2C_1A_RPSignUpSignInNewRoomv3.1/SelfAsserted",
                 params={
                     "tx": "StateProperties=" + state_properties,
@@ -158,7 +176,6 @@ class RemehaHomeAPI:
                     "signInName": self.email,
                     "password": self.password,
                 },
-                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -176,7 +193,8 @@ class RemehaHomeAPI:
         response_json = json.loads(response.text)
 
         try:
-            response = self._session.get(
+            response = self._request_with_retry(
+                "get",
                 "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/B2C_1A_RPSignUpSignInNewRoomv3.1/api/CombinedSigninAndSignup/confirmed",
                 params={
                     "rememberMe": "false",
@@ -185,7 +203,6 @@ class RemehaHomeAPI:
                     "p": "B2C_1A_RPSignUpSignInNewRoomv3.1",
                 },
                 allow_redirects=False,
-                timeout=10,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -221,12 +238,13 @@ class RemehaHomeAPI:
 
     def _request_new_token(self, grant_params):
         # Logic for requesting a new access token
-        with self._session.post(
-            "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/token?p=B2C_1A_RPSignUpSignInNewRoomV3.1",
-            data=grant_params,
-            allow_redirects=True,
-            timeout=10,
-        ) as response:
+        try:
+            response = self._request_with_retry(
+                "post",
+                "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/token?p=B2C_1A_RPSignUpSignInNewRoomV3.1",
+                data=grant_params,
+                allow_redirects=True,
+            )
             if response.status_code != 200:
                 response_json = response.json()
                 Domoticz.Log(
@@ -235,6 +253,13 @@ class RemehaHomeAPI:
                 )
             response.raise_for_status()
             response_json = response.json()
+        except requests.exceptions.RequestException as e:
+            reason = getattr(e, 'reason', e)
+            Domoticz.Error(f"new access token error: {type(e).__name__}: {reason}")
+            return None
+        except Exception as e:
+            Domoticz.Error(f"new access token error: {e}")
+
         return response_json
 
     def cleanup(self):
@@ -257,8 +282,9 @@ class RemehaHomeAPI:
 
         #Domoticz.Log("Getting device states...")
         try:
-            response = self._session.get(
-                "https://api.bdrthermea.net/Mobile/api/homes/dashboard", headers=headers, timeout=10
+            response = self._request_with_retry(
+                "get",
+                "https://api.bdrthermea.net/Mobile/api/homes/dashboard", headers=headers
             )
 
             response.raise_for_status()
@@ -348,18 +374,18 @@ class RemehaHomeAPI:
         try:
             json_data = {'roomTemperatureSetPoint': room_temperature_setpoint}
             if Devices[8].sValue == "10": #If zonemode is manual then adjust the manual temp
-                response = self._session.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/manual',
                     headers=headers,
                     json=json_data,
-                    timeout=10,
                     )
             else: # zonemode is not manual then temporary override
-                response = self._session.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/temporary-override',
                     headers=headers,
                     json=json_data,
-                    timeout=10,
                     )
             response.raise_for_status()
             Domoticz.Log(f"Temperature set successfully to {room_temperature_setpoint}")
@@ -380,7 +406,8 @@ class RemehaHomeAPI:
         yearly_url = f"https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/yearly?startDate=1900-01-01T00:00:00.000Z&endDate={last_day_of_last_year.strftime('%Y-%m-%dT00:00:00.000Z')}"
 
         try:
-            yearly_data = requests.get(yearly_url, headers=headers).json()
+            yearly_response = self._request_with_retry("get", yearly_url, headers=headers)
+            yearly_data = yearly_response.json()
 
             # Extract "heatingEnergyConsumed" from each row in the yearly response body
             heating_energy_consumed_values_yearly = [entry["heatingEnergyConsumed"] for entry in yearly_data["data"]]
@@ -406,7 +433,8 @@ class RemehaHomeAPI:
         try:
             monthly_url = f"https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/monthly?startDate={datetime.datetime.now().year}-01-01T00:00:00.000Z&endDate={end_of_current_month.strftime('%Y-%m-%dT00:00:00.000Z')}"
             #print(monthly_url)
-            monthly_data = requests.get(monthly_url, headers=headers).json()
+            monthly_response = self._request_with_retry("get", monthly_url, headers=headers)
+            monthly_data = monthly_response.json()
 
             # Extract "heatingEnergyConsumed" from each row in the monthly response body
             heating_energy_consumed_values_monthly = [entry["heatingEnergyConsumed"] for entry in monthly_data["data"]]
@@ -444,7 +472,8 @@ class RemehaHomeAPI:
         end_of_today_string = today_end.strftime('%Y-%m-%dT%H:%M:%S.999Z')
 
         try:
-            response = requests.get(
+            response = self._request_with_retry(
+                "get",
                 f'https://api.bdrthermea.net/Mobile/api/appliances/{appliance_id}/energyconsumption/daily?startDate={today_string}&endDate={end_of_today_string}',
                 headers=headers
             )
@@ -514,7 +543,8 @@ class RemehaHomeAPI:
         try:
             if level == 0: # Scheduling mode
                 json_data = {"heatingProgramId": 1}
-                response = requests.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/schedule',
                     headers=headers,
                     json=json_data
@@ -524,7 +554,8 @@ class RemehaHomeAPI:
             elif level == 10: # Manual mode
                 room_temperature_setpoint = float(Devices[4].sValue)
                 json_data = {"roomTemperatureSetPoint": room_temperature_setpoint}
-                response = requests.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/manual',
                     headers=headers,
                     json=json_data
@@ -534,19 +565,19 @@ class RemehaHomeAPI:
             elif level == 20: # TemporaryOverride mode
                 room_temperature_setpoint = float(Devices[4].sValue)
                 json_data = {'roomTemperatureSetPoint': room_temperature_setpoint}
-                response = self._session.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/temporary-override',
                     headers=headers,
                     json=json_data,
-                    timeout=10,
                     )
                 response.raise_for_status()
                 Domoticz.Log("Zonemode succesfully set to TemporaryOverride")
             elif level == 30: # FrostProtection mode
-                response = self._session.post(
+                response = self._request_with_retry(
+                    "post",
                     f'https://api.bdrthermea.net/Mobile/api/climate-zones/{climate_zone_id}/modes/anti-frost',
                     headers=headers,
-                    timeout=10,
                     )
                 response.raise_for_status()
                 Domoticz.Log("Zonemode succesfully set to FrostProtection")

--- a/plugin.py
+++ b/plugin.py
@@ -492,10 +492,6 @@ class RemehaHomeAPI:
                 Devices[13].Update(nValue=0, sValue="Off")
 
         except Exception as e:
-            Domoticz.Error(f"Error during GET request for dashboard: {type(e).__name__}: {e}")
-            return None
-
-        except Exception as e:
             Domoticz.Error(f"Error making GET request: {e}")
 
     def set_temperature(self, access_token, room_temperature_setpoint):


### PR DESCRIPTION
This update will retry each API call with a 5-second timeout, this to avoid a hanging API call causing the plugin hardware to cause hard failures.