### PR TITLE
Add thermostat6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,22 @@ It was further developed by Tuk90, GizMoCuz. jvanderzande added the T6 Thermosta
   - **No** means you will get 2 separate devices: Thermostat and Temperature device.
  
   **IMPORTANT**
-  When changing from separate SetTemp&Temperature devices to the new combined Thermostat6, you need to update the scripts setting the Themostat device when using updatedevice to include both the "Temp;SetTemp" in sValue!
+  - When changing from separate SetTemp&Temperature devices to the new combined Thermostat6, you need to update the scripts setting the Themostat device when using updatedevice to include both the "Temp;SetTemp" in sValue!
+  - process performed when changed to **Yes** and previously **No**:
+    - unit 1 - "RoomTemperature" will be removed
+    - unit 4 - "setPoint" will be renamed to "OLD_setpoint" and disabled.
+    - unit 1 - "setPoint" type Thermostat6 will be created.
+  - process performed when changed to **No** and previously **Yes**:
+    - unit 1 - "setPoint" will be removed
+    - unit 4 - "setPoint" will be renamed back to  "setpoint" and enabled.
+    - unit 1 - "RoomTemperature" will be created.
 
 ## Devices
 The plugin creates the following devices in Domoticz:
-1. Room Temperature
+1. Setpoint & Room Temperature  (-or- Room Temperature when not combined)
 2. Outdoor Temperature
 3. Water Pressure
-4. Setpoint
+4. None (-or- Setpoint when not combined)
 5. Domestic Hot Water Temperature
 6. Energy Consumption
 7. Energy Delivered

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Domoticz Python plugin integrates with the Remeha Home API, providing real-
 
 ## Credits
 This plugin is based on the Remeha Home Python library by Michiel Visser, available at [GitHub - Remeha Home Library](https://github.com/msvisser/remeha_home).
-It was further developed by Tuk90 & GizMoCuzand now transferred to jvanderzande.
+It was further developed by Tuk90, GizMoCuz. jvanderzande added the T6 Thermostat option and added some code to avoid hardware failures due to slow responses from the Remeha website.
 
 ## Installation
 1. Clone this repository into the Domoticz plugins folder using the following command: git clone https://github.com/jvanderzande/RemehaHome-Domoticz.git
@@ -16,6 +16,9 @@ It was further developed by Tuk90 & GizMoCuzand now transferred to jvanderzande.
 - **Email:** Your Remeha Home account email.
 - **Password:** Your Remeha Home account password.
 - **Poll Interval:** Poll Interval (default 30 seconds). If you choose an amount higher than 30 seconds then set the value of Data Timeout to a higher value to prevent your logs from being flooded with 'timeout' error messages.
+- **Combined TempSettemp:** 
+  - **Yes** means you will get the new Thermostat6 device which combines the temperature and SetTemp into one device.
+  - **No** means you will get 2 separate devices: Thermostat and Temperature device.
 
 ## Devices
 The plugin creates the following devices in Domoticz:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ It was further developed by Tuk90, GizMoCuz. jvanderzande added the T6 Thermosta
 - **Combined TempSettemp:** 
   - **Yes** means you will get the new Thermostat6 device which combines the temperature and SetTemp into one device.
   - **No** means you will get 2 separate devices: Thermostat and Temperature device.
+ 
+  **IMPORTANT**
+  When changing from separate SetTemp&Temperature devices to the new combined Thermostat6, you need to update the scripts setting the Themostat device when using updatedevice to include both the "Temp;SetTemp" in sValue!
 
 ## Devices
 The plugin creates the following devices in Domoticz:

--- a/plugin.py
+++ b/plugin.py
@@ -83,9 +83,9 @@ class RemehaHomeAPI:
 
         # Called when the plugin is started
         if self.usecombined:
-           Domoticz.Log("Remeha Home Plugin started with combined temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
+           Domoticz.Status("Remeha Home Plugin started with combined temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
         else:
-           Domoticz.Log("Remeha Home Plugin started with separate temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
+           Domoticz.Status("Remeha Home Plugin started with separate temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
 
         # Check if there are no existing devices
         self.createDevices()

--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,5 @@
 """
-<plugin key="RemehaHome" name="Remeha Home Plugin" author="Nick Baring/GizMoCuz" version="1.4.1">
+<plugin key="RemehaHome" name="Remeha Home Plugin" author="Nick Baring/GizMoCuz/jvdzande" version="1.4.2">
     <params>
         <param field="Mode1" label="Email" width="200px" required="true"/>
         <param field="Mode2" label="Password" width="200px" password="true" required="true"/>
@@ -9,6 +9,12 @@
                 <option label="1 minute" value="60" default="true"/>
                 <option label="2 minutes" value="120"/>
                 <option label="5 minutes" value="300"/>
+            </options>
+        </param>
+        <param field="Mode4" label="Combined TempSettemp" width="100px" required="true">
+            <options>
+                <option label="Yes" value="Y" default="true"/>
+                <option label="No" value="N"/>
             </options>
         </param>
     </params>
@@ -24,6 +30,7 @@ import requests
 import datetime
 import calendar
 import time
+import re
 
 class RemehaHomeAPI:
     def __init__(self):
@@ -31,6 +38,9 @@ class RemehaHomeAPI:
         self._session = requests.Session()
         self.email = ""
         self.password = ""
+        self.domoticzbuild = 0
+        self.usecombined = False
+        self.poll_interval = 0
         self.LastWebUpdate = None
 
 
@@ -53,14 +63,12 @@ class RemehaHomeAPI:
 
     def onStart(self):
         # Called when the plugin is started
-        Domoticz.Log("Remeha Home Plugin started.")
+        Domoticz.Log("Remeha Home Plugin started. Domoticz version: " + Parameters["DomoticzVersion"])
 
         # Read options from Domoticz GUI
         self.readOptions()
         # Check if there are no existing devices
-        if len(Devices) != 13:
-            # Example: Create devices for temperature, pressure, and setpoint
-            self.createDevices()
+        self.createDevices()
 
         # Set the poll interval to 5 seconds and test for the set real update time in onheartbeat() to allow for longer than 30 seconds
         Domoticz.Heartbeat(5)
@@ -84,24 +92,72 @@ class RemehaHomeAPI:
         if self.poll_interval > 300:
             self.poll_interval = 300
 
+        # Get DomoticzBuild number
+        DBa = re.search(r"\(build\s+(\d+)\)", Parameters["DomoticzVersion"])
+        if DBa:
+            self.domoticzbuild = int(DBa.group(1))
+        self.usecombined = (self.domoticzbuild > 16987 and Parameters["Mode4"] == "Y")
+
     def createDevices(self):
         # Declare Devices variable
         global Devices
 
         # Create devices for temperature, pressure, and setpoint
-        Domoticz.Device(Name="roomTemperature", Unit=1, TypeName="Temperature", Used=1).Create()
-        Domoticz.Device(Name="outdoorTemperature", Unit=2, TypeName="Temperature", Used=1).Create()
-        Domoticz.Device(Name="waterPressure", Unit=3, TypeName="Pressure", Used=1).Create()
-        Domoticz.Device(Name="setPoint", Unit=4, TypeName="Setpoint", Used=1).Create()
-        Domoticz.Device(Name="dhwTemperature", Unit=5, TypeName="Temperature", Used=1).Create()
-        Domoticz.Device(Name="EnergyConsumption", Unit=6, Type=243, TypeName="Kwh", Subtype=29, Used=1).Create()
-        Domoticz.Device(Name="gasCalorificValue", Unit=7, Type=243, Subtype=31, Used=1).Create()
-        Domoticz.Device(Name="zoneMode", Unit=8, TypeName="Selector Switch", Image=15, Options={"LevelNames":"Scheduling|Manual|TemporaryOverride|FrostProtection", "LevelOffHidden": "false", "SelectorStyle": "1"}, Used=1).Create()
-        Domoticz.Device(Name="waterPressureToLow", Unit=9, TypeName="Switch", Switchtype=0, Image=13, Used=1).Create()
-        Domoticz.Device(Name="EnergyDelivered", Unit=10, Type=243, TypeName="Kwh", Subtype=29, Switchtype=4, Used=1).Create()
-        Domoticz.Device(Name="Status", Unit=11, TypeName="Text", Image=15, Used=1).Create()
-        Domoticz.Device(Name="seasonalEfficiency", Unit=12, Type=243, Subtype=31, Used=1).Create()
-        Domoticz.Device(Name="firePlaceModeActive", Unit=13, TypeName="Switch", Switchtype=0, Image=10, Used=1).Create()
+        # Use Combined device when supported and requested in the hardware page
+        if (self.usecombined):
+            OrgSetTempName = ''
+            if 1 in Devices and Devices[1].Type != 73 :
+                Domoticz.Log(f"Deleted old Temp device: {Devices[1].Name} Type={Devices[1].Type}, SubType={Devices[1].SubType}")
+                Devices[1].Delete()
+                Domoticz.Log(f"Renamed Disabled Old SetTemp: {Devices[4].Name} ")
+                OrgSetTempName = Devices[4].Name
+                newname = "OLD_"+OrgSetTempName
+                Devices[4].Update(
+                    nValue=Devices[4].nValue,
+                    sValue=Devices[4].sValue,
+                    Name=newname,
+                    Used=0
+                )
+
+            if 1 not in Devices:
+                Domoticz.Device(Name="roomTempsetPoint", Unit=1, Type=73, Subtype=0, Used=1).Create()
+                if OrgSetTempName != '':
+                    Devices[1].Update(
+                        nValue=Devices[1].nValue,
+                        sValue=Devices[1].sValue,
+                        Name=OrgSetTempName,
+                        Used=1
+                    )
+                Domoticz.Log(f"Created combined device: {Devices[1].Name} Type={Devices[1].Type}, SubType={Devices[1].SubType}")
+        else:
+            if 1 not in Devices:
+                Domoticz.Device(Name="roomTemperature", Unit=1, TypeName="Temperature", Used=1).Create()
+                Domoticz.Log(f"Created seperate Temp device: {Devices[1].Name}")
+            if 4 not in Devices:
+                Domoticz.Device(Name="setPoint", Unit=4, TypeName="Setpoint", Used=1).Create()
+                Domoticz.Log(f"Created seperate SetTemp device: {Devices[4].Name}")
+            if 2 not in Devices:
+                Domoticz.Device(Name="outdoorTemperature", Unit=2, TypeName="Temperature", Used=1).Create()
+            if 3 not in Devices:
+                Domoticz.Device(Name="waterPressure", Unit=3, TypeName="Pressure", Used=1).Create()
+            if 5 not in Devices:
+                Domoticz.Device(Name="dhwTemperature", Unit=5, TypeName="Temperature", Used=1).Create()
+            if 6 not in Devices:
+                Domoticz.Device(Name="EnergyConsumption", Unit=6, Type=243, TypeName="Kwh", Subtype=29, Used=1).Create()
+            if 7 not in Devices:
+                Domoticz.Device(Name="gasCalorificValue", Unit=7, Type=243, Subtype=31, Used=1).Create()
+            if 8 not in Devices:
+                Domoticz.Device(Name="zoneMode", Unit=8, TypeName="Selector Switch", Image=15, Options={"LevelNames":"Scheduling|Manual|TemporaryOverride|FrostProtection", "LevelOffHidden": "false", "SelectorStyle": "1"}, Used=1).Create()
+            if 9 not in Devices:
+                Domoticz.Device(Name="waterPressureToLow", Unit=9, TypeName="Switch", Switchtype=0, Image=13, Used=1).Create()
+            if 10 not in Devices:
+                Domoticz.Device(Name="EnergyDelivered", Unit=10, Type=243, TypeName="Kwh", Subtype=29, Switchtype=4, Used=1).Create()
+            if 11 not in Devices:
+                Domoticz.Device(Name="Status", Unit=11, TypeName="Text", Image=15, Used=1).Create()
+            if 12 not in Devices:
+                Domoticz.Device(Name="seasonalEfficiency", Unit=12, Type=243, Subtype=31, Used=1).Create()
+            if 13 not in Devices:
+                Domoticz.Device(Name="firePlaceModeActive", Unit=13, TypeName="Switch", Switchtype=0, Image=10, Used=1).Create()
 
 
 
@@ -337,15 +393,17 @@ class RemehaHomeAPI:
             except:
                 pass
 
-            #if str(Devices[1].sValue) != str(value_room_temperature):
-            Devices[1].Update(nValue=0, sValue=str(value_room_temperature))
+            if (self.usecombined and Devices[1].Type == 73):
+                Devices[1].Update(nValue=0, sValue=str(value_room_temperature) + ";" + str(value_setpoint))
+            else:
+                Devices[1].Update(nValue=0, sValue=str(value_room_temperature))
+                Devices[4].Update(nValue=0, sValue=str(value_setpoint))
+
             #if str(Devices[2].sValue) != str(value_outdoor_temperature):
             if response_json["appliances"][0]["capabilityOutdoorTemperature"] is True:
                 Devices[2].Update(nValue=0, sValue=str(value_outdoor_temperature))
             #if str(Devices[3].sValue) != str(value_water_pressure):
             Devices[3].Update(nValue=0, sValue=str(value_water_pressure))
-            #if str(Devices[4].sValue) != str(value_setpoint):
-            Devices[4].Update(nValue=0, sValue=str(value_setpoint))
             #if str(Devices[5].sValue) != str(value_dhwTemperature):
             if value_dhwTemperature is not None:
                 Devices[5].Update(nValue=0, sValue=str(value_dhwTemperature))
@@ -468,7 +526,6 @@ class RemehaHomeAPI:
                 monthly_url,
                 headers=headers
             )
-
             monthly_response.raise_for_status()
             monthly_data = monthly_response.json()
 
@@ -703,7 +760,11 @@ class RemehaHomeAPI:
         access_token = getattr(self, 'access_token', None)
         if access_token and self.check_token_validity(access_token) == "valid":
             try:
-                if unit == 4:  # setpoint device
+                if unit == 1: # New combined setpoint device
+                    if command == 'Set Level':
+                        room_temperature_setpoint = float(level)
+                        self.set_temperature(access_token, room_temperature_setpoint)
+                elif unit == 4:  # setpoint device
                     if command == 'Set Level':
                         room_temperature_setpoint = float(level)
                         self.set_temperature(access_token, room_temperature_setpoint)

--- a/plugin.py
+++ b/plugin.py
@@ -19,8 +19,8 @@
         </param>
         <param field="Mode4" label="Combined TempSettemp" width="100px" required="true">
             <options>
-                <option label="Yes" value="Y" default="true"/>
-                <option label="No" value="N"/>
+                <option label="Yes" value="Yes" default="true"/>
+                <option label="No" value="No"/>
             </options>
         </param>
     </params>
@@ -68,11 +68,16 @@ class RemehaHomeAPI:
         return None
 
     def onStart(self):
-        # Called when the plugin is started
-        Domoticz.Log("Remeha Home Plugin started. Domoticz version: " + Parameters["DomoticzVersion"])
 
         # Read options from Domoticz GUI
         self.readOptions()
+
+        # Called when the plugin is started
+        if self.usecombined:
+           Domoticz.Log("Remeha Home Plugin started with combined temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
+        else:
+           Domoticz.Log("Remeha Home Plugin started with separate temp-settemp. Domoticz version: " + Parameters["DomoticzVersion"])
+
         # Check if there are no existing devices
         self.createDevices()
 
@@ -86,6 +91,7 @@ class RemehaHomeAPI:
 
     def readOptions(self):
         # Read options from Domoticz GUI
+
         if Parameters["Mode1"]:
             self.email = Parameters["Mode1"]
         if "Mode2" in Parameters and Parameters["Mode2"]:
@@ -98,11 +104,7 @@ class RemehaHomeAPI:
         if self.poll_interval > 300:
             self.poll_interval = 300
 
-        # Get DomoticzBuild number
-        DBa = re.search(r"\(build\s+(\d+)\)", Parameters["DomoticzVersion"])
-        if DBa:
-            self.domoticzbuild = int(DBa.group(1))
-        self.usecombined = (self.domoticzbuild > 16987 and Parameters["Mode4"] == "Y")
+        self.usecombined = (Parameters["Mode4"] == "Yes")
 
     def createDevices(self):
         # Declare Devices variable
@@ -111,59 +113,74 @@ class RemehaHomeAPI:
         # Create devices for temperature, pressure, and setpoint
         # Use Combined device when supported and requested in the hardware page
         if (self.usecombined):
-            OrgSetTempName = ''
+            OrgTempsValue="18.0"
+            OrgSetTempName = "roomTempsetPoint"
+            OrgSetTempsValue = "15.0"
+            OrgSetTempnValue = 0
+            # Delete old Temp device as that has to become the Combined SetTemp Device
             if 1 in Devices and Devices[1].Type != 73 :
-                Domoticz.Log(f"Deleted old Temp device: {Devices[1].Name} Type={Devices[1].Type}, SubType={Devices[1].SubType}")
-                Devices[1].Delete()
-                Domoticz.Log(f"Renamed Disabled Old SetTemp: {Devices[4].Name} ")
+                # retrieve current (4) - SetTemp device info
                 OrgSetTempName = Devices[4].Name
+                OrgSetTempsValue= Devices[4].sValue
+                OrgSetTempnValue= Devices[4].nValue
+                # retrieve current (1) - Temp device info
+                OrgTempsValue= Devices[1].sValue
+                # Delete old (1) - Temp device to trigger the below device creation
+                Domoticz.Log(f"Deleted old Temp device: \"{Devices[1].Name}\" Type={Devices[1].Type}, SubType={Devices[1].SubType}")
+                Devices[1].Delete()
+
+                # Disable&Rename old SetTemp device
                 newname = "OLD_"+OrgSetTempName
-                Devices[4].Update(
-                    nValue=Devices[4].nValue,
-                    sValue=Devices[4].sValue,
-                    Name=newname,
-                    Used=0
-                )
+                if 4 in Devices and Devices[4].Type != 73:
+                    Devices[4].Update(
+                        nValue=Devices[4].nValue,
+                        sValue=Devices[4].sValue,
+                        Name=newname,
+                        Used=0
+                    )
+                    Domoticz.Log(f"Renamed & Disabled Old SetTemp device to: \"{Devices[4].Name}\"")
 
             if 1 not in Devices:
-                Domoticz.Device(Name="roomTempsetPoint", Unit=1, Type=73, Subtype=0, Used=1).Create()
-                if OrgSetTempName != '':
-                    Devices[1].Update(
-                        nValue=Devices[1].nValue,
-                        sValue=Devices[1].sValue,
-                        Name=OrgSetTempName,
-                        Used=1
-                    )
+                Domoticz.Device(Name=OrgSetTempName, Unit=1, Type=73, Subtype=0, Used=1).Create()
+                Devices[1].Update(
+                    nValue=OrgSetTempnValue,
+                    sValue=OrgTempsValue + ";" + OrgSetTempsValue,
+                    Name=OrgSetTempName,
+                    Used=1
+                )
                 Domoticz.Log(f"Created combined device: {Devices[1].Name} Type={Devices[1].Type}, SubType={Devices[1].SubType}")
         else:
+            # Use separate Thermostat devices for SetTemp and temperature
             if 1 not in Devices:
                 Domoticz.Device(Name="roomTemperature", Unit=1, TypeName="Temperature", Used=1).Create()
                 Domoticz.Log(f"Created seperate Temp device: {Devices[1].Name}")
             if 4 not in Devices:
                 Domoticz.Device(Name="setPoint", Unit=4, TypeName="Setpoint", Used=1).Create()
                 Domoticz.Log(f"Created seperate SetTemp device: {Devices[4].Name}")
-            if 2 not in Devices:
-                Domoticz.Device(Name="outdoorTemperature", Unit=2, TypeName="Temperature", Used=1).Create()
-            if 3 not in Devices:
-                Domoticz.Device(Name="waterPressure", Unit=3, TypeName="Pressure", Used=1).Create()
-            if 5 not in Devices:
-                Domoticz.Device(Name="dhwTemperature", Unit=5, TypeName="Temperature", Used=1).Create()
-            if 6 not in Devices:
-                Domoticz.Device(Name="EnergyConsumption", Unit=6, Type=243, TypeName="Kwh", Subtype=29, Used=1).Create()
-            if 7 not in Devices:
-                Domoticz.Device(Name="gasCalorificValue", Unit=7, Type=243, Subtype=31, Used=1).Create()
-            if 8 not in Devices:
-                Domoticz.Device(Name="zoneMode", Unit=8, TypeName="Selector Switch", Image=15, Options={"LevelNames":"Scheduling|Manual|TemporaryOverride|FrostProtection", "LevelOffHidden": "false", "SelectorStyle": "1"}, Used=1).Create()
-            if 9 not in Devices:
-                Domoticz.Device(Name="waterPressureToLow", Unit=9, TypeName="Switch", Switchtype=0, Image=13, Used=1).Create()
-            if 10 not in Devices:
-                Domoticz.Device(Name="EnergyDelivered", Unit=10, Type=243, TypeName="Kwh", Subtype=29, Switchtype=4, Used=1).Create()
-            if 11 not in Devices:
-                Domoticz.Device(Name="Status", Unit=11, TypeName="Text", Image=15, Used=1).Create()
-            if 12 not in Devices:
-                Domoticz.Device(Name="seasonalEfficiency", Unit=12, Type=243, Subtype=31, Used=1).Create()
-            if 13 not in Devices:
-                Domoticz.Device(Name="firePlaceModeActive", Unit=13, TypeName="Switch", Switchtype=0, Image=10, Used=1).Create()
+
+        # other devices
+        if 2 not in Devices:
+            Domoticz.Device(Name="outdoorTemperature", Unit=2, TypeName="Temperature", Used=1).Create()
+        if 3 not in Devices:
+            Domoticz.Device(Name="waterPressure", Unit=3, TypeName="Pressure", Used=1).Create()
+        if 5 not in Devices:
+            Domoticz.Device(Name="dhwTemperature", Unit=5, TypeName="Temperature", Used=1).Create()
+        if 6 not in Devices:
+            Domoticz.Device(Name="EnergyConsumption", Unit=6, Type=243, TypeName="Kwh", Subtype=29, Used=1).Create()
+        if 7 not in Devices:
+            Domoticz.Device(Name="gasCalorificValue", Unit=7, Type=243, Subtype=31, Used=1).Create()
+        if 8 not in Devices:
+            Domoticz.Device(Name="zoneMode", Unit=8, TypeName="Selector Switch", Image=15, Options={"LevelNames":"Scheduling|Manual|TemporaryOverride|FrostProtection", "LevelOffHidden": "false", "SelectorStyle": "1"}, Used=1).Create()
+        if 9 not in Devices:
+            Domoticz.Device(Name="waterPressureToLow", Unit=9, TypeName="Switch", Switchtype=0, Image=13, Used=1).Create()
+        if 10 not in Devices:
+            Domoticz.Device(Name="EnergyDelivered", Unit=10, Type=243, TypeName="Kwh", Subtype=29, Switchtype=4, Used=1).Create()
+        if 11 not in Devices:
+            Domoticz.Device(Name="Status", Unit=11, TypeName="Text", Image=15, Used=1).Create()
+        if 12 not in Devices:
+            Domoticz.Device(Name="seasonalEfficiency", Unit=12, Type=243, Subtype=31, Used=1).Create()
+        if 13 not in Devices:
+            Domoticz.Device(Name="firePlaceModeActive", Unit=13, TypeName="Switch", Switchtype=0, Image=10, Used=1).Create()
 
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -159,13 +159,29 @@ class RemehaHomeAPI:
                 )
                 Domoticz.Log(f"Created combined device: {Devices[1].Name} Type={Devices[1].Type}, SubType={Devices[1].SubType}")
         else:
+            if 1 in Devices and Devices[1].Type == 73 :
+                Domoticz.Log(f"Deleted Combined SetTemp device: \"{Devices[1].Name}\"")
+                Devices[1].Delete();
+                newname = "roomTempsetPoint"
+                if 4 in Devices:
+                    # remove added "OLD_" prefix and enable previous define SetTemp device
+                    newname = Devices[4].Name.replace("OLD_","")
+                if 4 in Devices:
+                    Devices[4].Update(
+                        nValue=Devices[4].nValue,
+                        sValue=Devices[4].sValue,
+                        Name=newname,
+                        Used=1
+                    )
+                    Domoticz.Log(f"Renamed Old SetTemp device back to: \"{Devices[4].Name}\"")
+
             # Use separate Thermostat devices for SetTemp and temperature
             if 1 not in Devices:
                 Domoticz.Device(Name="roomTemperature", Unit=1, TypeName="Temperature", Used=1).Create()
-                Domoticz.Log(f"Created seperate Temp device: {Devices[1].Name}")
+                Domoticz.Log(f"Created separate Temp device: {Devices[1].Name}")
             if 4 not in Devices:
                 Domoticz.Device(Name="setPoint", Unit=4, TypeName="Setpoint", Used=1).Create()
-                Domoticz.Log(f"Created seperate SetTemp device: {Devices[4].Name}")
+                Domoticz.Log(f"Created separate SetTemp device: {Devices[4].Name}")
 
         # other devices
         if 2 not in Devices:


### PR DESCRIPTION
Added support for Thermostat6 combined device.
New plugin installation will use the new Thermostat6 by default unless set to No.
Existing installations with continue with the 2 existing separate devices, and you can combine them when you like.